### PR TITLE
feat: add yet-another-agent-harness to projects list

### DIFF
--- a/templates/README.md.tpl
+++ b/templates/README.md.tpl
@@ -13,6 +13,10 @@ I am a software engineer obsessed with DevOps, Serverless, Kubernetes, and latel
 [![](https://img.shields.io/badge/-@__ediri-E4405F?style=for-the-badge&logo=instagram&logoColor=white)](https://www.instagram.com/_ediri/)
 
 ## 🏗️ My Projects
+[yet-another-agent-harness](https://github.com/dirien/yet-another-agent-harness)
+
+A Go agent harness for Claude Code — runtime hooks, MCP server, session tracking, middleware chains, and full config generation in one binary.
+
 [minectl 🗺](https://github.com/dirien/minectl)
 
 Spin up Minecraft servers on any cloud provider from the command line.


### PR DESCRIPTION
## Summary
- Adds [yet-another-agent-harness](https://github.com/dirien/yet-another-agent-harness) as the first entry in the My Projects section of the README template

## Test plan
- [ ] Verify the README template renders correctly with the new project entry